### PR TITLE
gudgl/use session id as agent name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dev/node_modules
 # Dependency directories (remove the comment below to include it)
 # vendor/
 /dist
+
+# Goland IDE files
+.idea

--- a/api/session.go
+++ b/api/session.go
@@ -20,15 +20,10 @@ type AgentConfig struct {
 	MeshID     string
 	MeshIDHex  string
 	MeshServer string
-	agentName  string
+	AgentName  string `json:"agentName"`
 }
 
 // SetAgentName sets the sessionID as agentName in AgentConfig
 func (ac *AgentConfig) SetAgentName(sessionID string) {
-	ac.agentName = strings.ReplaceAll(sessionID, " ", "_")
-}
-
-// GetAgentName returns the agentName
-func (ac AgentConfig) GetAgentName() string {
-	return ac.agentName
+	ac.AgentName = strings.ReplaceAll(sessionID, " ", "_")
 }

--- a/api/session.go
+++ b/api/session.go
@@ -1,6 +1,9 @@
 package api
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type Session struct {
 	ID          string
@@ -17,4 +20,15 @@ type AgentConfig struct {
 	MeshID     string
 	MeshIDHex  string
 	MeshServer string
+	agentName  string
+}
+
+// SetAgentName sets the sessionID as agentName in AgentConfig
+func (ac *AgentConfig) SetAgentName(sessionID string) {
+	ac.agentName = strings.ReplaceAll(sessionID, " ", "_")
+}
+
+// GetAgentName returns the agentName
+func (ac AgentConfig) GetAgentName() string {
+	return ac.agentName
 }

--- a/handler/create.go
+++ b/handler/create.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-
+	
 	"github.com/rs/zerolog/log"
-
+	
 	"github.com/cloudradar-monitoring/plexus/api"
 	"github.com/cloudradar-monitoring/plexus/control"
 	"github.com/cloudradar-monitoring/plexus/token"
@@ -39,15 +39,15 @@ func (h *Handler) CreateSession(rw http.ResponseWriter, r *http.Request) {
 		api.WriteBadRequestJSON(rw, fmt.Sprintf("invalid ttl %s: %s", id, err))
 		return
 	}
-
+	
 	h.lock.Lock()
 	defer h.lock.Unlock()
-
+	
 	if _, ok := h.sessions[id]; ok {
 		api.WriteBadRequestJSON(rw, fmt.Sprintf("session with id %s does already exist", id))
 		return
 	}
-
+	
 	mc, err := control.Connect(h.cfg)
 	defer mc.Close()
 	if err != nil {
@@ -65,7 +65,7 @@ func (h *Handler) CreateSession(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sessionToken := token.NewAuth()
-
+	
 	session := &Session{
 		Token:     sessionToken,
 		ID:        id,
@@ -84,7 +84,7 @@ func (h *Handler) CreateSession(rw http.ResponseWriter, r *http.Request) {
 	
 	session.SetAgentName()
 	h.sessions[id] = session
-
+	
 	go func() {
 		<-time.After(time.Duration(ttl) * time.Second)
 		h.lock.Lock()
@@ -97,7 +97,7 @@ func (h *Handler) CreateSession(rw http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}()
-
+	
 	rw.Header().Add("content-type", "application/json")
 	rw.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(rw).Encode(&api.Session{

--- a/handler/create.go
+++ b/handler/create.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-	
+
 	"github.com/rs/zerolog/log"
-	
+
 	"github.com/cloudradar-monitoring/plexus/api"
 	"github.com/cloudradar-monitoring/plexus/control"
 	"github.com/cloudradar-monitoring/plexus/token"
@@ -39,15 +39,15 @@ func (h *Handler) CreateSession(rw http.ResponseWriter, r *http.Request) {
 		api.WriteBadRequestJSON(rw, fmt.Sprintf("invalid ttl %s: %s", id, err))
 		return
 	}
-	
+
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	
+
 	if _, ok := h.sessions[id]; ok {
 		api.WriteBadRequestJSON(rw, fmt.Sprintf("session with id %s does already exist", id))
 		return
 	}
-	
+
 	mc, err := control.Connect(h.cfg)
 	defer mc.Close()
 	if err != nil {
@@ -65,7 +65,7 @@ func (h *Handler) CreateSession(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sessionToken := token.NewAuth()
-	
+
 	session := &Session{
 		Token:     sessionToken,
 		ID:        id,
@@ -81,10 +81,10 @@ func (h *Handler) CreateSession(rw http.ResponseWriter, r *http.Request) {
 			MeshType:   2,
 		},
 	}
-	
+
 	session.SetAgentName()
 	h.sessions[id] = session
-	
+
 	go func() {
 		<-time.After(time.Duration(ttl) * time.Second)
 		h.lock.Lock()
@@ -97,7 +97,7 @@ func (h *Handler) CreateSession(rw http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}()
-	
+
 	rw.Header().Add("content-type", "application/json")
 	rw.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(rw).Encode(&api.Session{

--- a/handler/create.go
+++ b/handler/create.go
@@ -81,6 +81,8 @@ func (h *Handler) CreateSession(rw http.ResponseWriter, r *http.Request) {
 			MeshType:   2,
 		},
 	}
+	
+	session.SetAgentName()
 	h.sessions[id] = session
 
 	go func() {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -3,7 +3,7 @@ package handler
 import (
 	"sync"
 	"time"
-
+	
 	"github.com/cloudradar-monitoring/plexus/api"
 	"github.com/cloudradar-monitoring/plexus/config"
 )
@@ -28,4 +28,14 @@ type Session struct {
 	AgentConfig        api.AgentConfig
 	ShareURL           string
 	ProxyClose         func()
+}
+
+// SetAgentName sets Session ID as agentName in Session.AgentConfig
+func (s *Session) SetAgentName() {
+	s.AgentConfig.SetAgentName(s.ID)
+}
+
+// GetAgentName returns the agentName from Session.AgentConfig
+func (s Session) GetAgentName() string {
+	return s.AgentConfig.GetAgentName()
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -20,6 +20,7 @@ type Handler struct {
 	lock     sync.RWMutex
 	sessions map[string]*Session
 }
+
 type Session struct {
 	ID                 string
 	Username, Password string
@@ -33,9 +34,4 @@ type Session struct {
 // SetAgentName sets Session ID as agentName in Session.AgentConfig
 func (s *Session) SetAgentName() {
 	s.AgentConfig.SetAgentName(s.ID)
-}
-
-// GetAgentName returns the agentName from Session.AgentConfig
-func (s Session) GetAgentName() string {
-	return s.AgentConfig.GetAgentName()
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -3,7 +3,7 @@ package handler
 import (
 	"sync"
 	"time"
-	
+
 	"github.com/cloudradar-monitoring/plexus/api"
 	"github.com/cloudradar-monitoring/plexus/config"
 )

--- a/handler/msh.go
+++ b/handler/msh.go
@@ -45,5 +45,5 @@ func (h *Handler) GetAgentMsh(rw http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(rw, "MeshType="+strconv.Itoa(session.AgentConfig.MeshType))
 	fmt.Fprintln(rw, "MeshID="+session.AgentConfig.MeshIDHex)
 	fmt.Fprintln(rw, "MeshServer="+session.AgentConfig.MeshServer)
-	fmt.Fprintln(rw, "agentName="+session.GetAgentName())
+	fmt.Fprintln(rw, "agentName="+session.AgentConfig.AgentName)
 }

--- a/handler/msh.go
+++ b/handler/msh.go
@@ -45,4 +45,5 @@ func (h *Handler) GetAgentMsh(rw http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(rw, "MeshType="+strconv.Itoa(session.AgentConfig.MeshType))
 	fmt.Fprintln(rw, "MeshID="+session.AgentConfig.MeshIDHex)
 	fmt.Fprintln(rw, "MeshServer="+session.AgentConfig.MeshServer)
+	fmt.Fprintln(rw, "agentName="+session.GetAgentName())
 }


### PR DESCRIPTION
## Problem
Connected agents are registered with the local hostname on the meshcentral server. This can quickly lead to conflicts if sessions run concurrently. Also, we cannot identify which session on Plexus belongs to which host on Meshcentral.

## Task
On the generated msh config, include the setting `agentName` and set it to the session id. This way, the session of plexus and the client name on Meshcentral always match.
https://github.com/Ylianst/MeshAgent#msh-format

Example of the AgentConfig including the `agentName`.
`curl -ks "https://localhost:8080/config/helping-joe:PFoRPrf1l2MbTafIIgTY"`

```text
ServerID=CAC3E1AA1E3DE7D03691237B687C4B554365FD29640AE56E23A5000138DA73E8ED483EE40E1900C355AB51694D15C070
MeshName=plexus/helping-joe/tcG7C
MeshType=2
MeshID=0xA67B726149B1448386B8CD41A53A47EAF3E26A045CF8422C4236A98B5B4656DC1C6FEB773A7FBCDA46A2382CEEEC07F7
MeshServer=wss://localhost:8080/agent/helping-joe:PFoRPrf1l2MbTafIIgTY
agentName=helping-joe
```

* Note that the key name must have the exact capitalization.
* Blanks are not allowed inside the agent name. Replace by underscores.