### PR TITLE
Add list active sessions endpoint

### DIFF
--- a/api/result.go
+++ b/api/result.go
@@ -15,6 +15,12 @@ func WriteResult(rw http.ResponseWriter, code int, result string) {
 	_ = json.NewEncoder(rw).Encode(&Result{Result: result})
 }
 
+func WriteJSONResponse(rw http.ResponseWriter, code int, response interface{}) {
+	rw.Header().Add("content-type", "application/json")
+	rw.WriteHeader(code)
+	_ = json.NewEncoder(rw).Encode(response)
+}
+
 type URLResponse struct {
 	URL string `json:"url"`
 }

--- a/api/session.go
+++ b/api/session.go
@@ -1,6 +1,8 @@
 package api
 
-import "time"
+import (
+	"time"
+)
 
 type Session struct {
 	ID          string
@@ -17,4 +19,13 @@ type AgentConfig struct {
 	MeshID     string
 	MeshIDHex  string
 	MeshServer string
+}
+
+type ListSessionsItem struct {
+	ID              string
+	SessionURL      string
+	AgentMSH        string
+	SessionUsername string `json:",omitempty"`
+	SessionPassword string `json:",omitempty"`
+	ExpiresAt       time.Time
 }

--- a/handler/list.go
+++ b/handler/list.go
@@ -1,0 +1,34 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cloudradar-monitoring/plexus/api"
+)
+
+// ListSessions godoc
+// @Summary Lists all active session.
+// @Tags session
+// @Produce  application/json
+// @Success 200 {array} api.Session
+// @Failure 400 {object} api.Error
+// @Failure 401 {object} api.Error
+// @Failure 500 {object} api.Error
+// @Router /session [get]
+func (h *Handler) ListSessions(rw http.ResponseWriter, r *http.Request) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	sessions := make([]*api.ListSessionsItem, 0, len(h.sessions))
+	for _, s := range h.sessions {
+		sessions = append(sessions, &api.ListSessionsItem{
+			ID:              s.ID,
+			SessionURL:      fmt.Sprintf("https://%s/session/%s", r.Host, s.ID),
+			AgentMSH:        fmt.Sprintf("https://%s/config/%s:%s", r.Host, s.ID, s.Token),
+			SessionUsername: s.Username,
+			SessionPassword: s.Password,
+			ExpiresAt:       s.ExpiresAt,
+		})
+	}
+	api.WriteJSONResponse(rw, http.StatusOK, sessions)
+}

--- a/router/router.go
+++ b/router/router.go
@@ -31,6 +31,7 @@ func New(h *handler.Handler) http.Handler {
 	r.Use(accessLog)
 
 	r.Post("/session", h.SessionCreationAuth(h.CreateSession))
+	r.Get("/session", h.SessionCreationAuth(h.ListSessions))
 	r.Get("/session/{id}", h.ShareSession)
 	r.Get("/session/{id}/url", h.ShareSessionURL)
 	r.Delete("/session/{id}", h.DeleteSession)


### PR DESCRIPTION
## Task
Implement an index endpoint that lists running session.

`curl -ks https://localhost:8080/session` must return the list of active session containing
* ID
* Session URL
* Agent MSH
* Expiry date
* Username and password of the session

```json
[
    {
        "ID": "helping-joe",
        "SessionURL": "https://localhost:8080/session/helping-joe",
        "AgentMSH": "https://localhost:8080/config/helping-joe:xddRGfuIOaqwBxVIWrnp",
        "SessionUser": "admin",
        "SessionPassword": "foobaz",
        "ExpiresAt": "2021-09-12T14:31:40.830231373+02:00"
    },
    {
        "ID": "test",
        "SessionURL": "https://localhost:8080/session/test",
        "AgentMSH": "https://localhost:8080/config/test:xddRGfuIOaqwBxVIWrnp",
        "SessionUser": "",
        "SessionPassword": "",
        "ExpiresAt": "2021-09-12T14:31:40.830231373+02:00"
    }
]
```